### PR TITLE
Implement multiplication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod mp_int {
         cmp::Ordering,
         fmt::Display,
         mem::size_of,
-        ops::{Add, AddAssign, Div, Index, IndexMut, Neg, Not, Rem, ShlAssign},
+        ops::{Add, AddAssign, Div, Index, IndexMut, Neg, Not, Rem, ShlAssign, Sub, SubAssign},
         slice::Iter,
     };
 
@@ -389,6 +389,21 @@ pub mod mp_int {
         fn neg(mut self) -> Self::Output {
             self.sign = !self.sign;
             self
+        }
+    }
+
+    impl Sub for &MPint {
+        type Output = MPint;
+        fn sub(self, rhs: Self) -> Self::Output {
+            let mut diff = self.clone();
+            diff -= rhs.clone();
+            diff
+        }
+    }
+
+    impl SubAssign for MPint {
+        fn sub_assign(&mut self, rhs: Self) {
+            *self += -rhs;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub mod mp_int {
     type DoubleDigitT = u128;
 
     /// Number of bits used per digit in the internal number system.
-    /// Must stay ≤64, else e.g. division will break, since we need "2*DIGIT_BITS"
-    /// for those calculations, while only ≤128bit are available "natively".
+    /// Must stay ≤64, since e.g. multiplication depends on "2*DIGIT_BITS" width
+    /// intermdiate results, while only ≤128bit are available "natively".
     const DIGIT_BITS: u32 = (size_of::<DigitT>() as u32) * 8;
 
     #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
@@ -574,6 +574,7 @@ pub mod mp_int {
                 }
 
                 // Prepare for easier partial product addition in next iteration.
+                // After last iteration, end_product has performed a full cycle.
                 end_product.rotate_digits_right(1);
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ pub mod mp_int {
     /// `const DIGIT_BITS`.
     /// __DO NOT CHANGE WITHOUT CAUTION__
     pub type DigitT = u64;
+    /// Type double the width of `DigitT`, sometimes needed for intermediary results
+    type DoubleDigitT = u128;
 
     /// Number of bits used per digit in the internal number system.
     /// Must stay ≤64, else e.g. division will break, since we need "2*DIGIT_BITS"
@@ -198,11 +200,11 @@ pub mod mp_int {
         pub fn div_with_rem(&self, divisor: DigitT) -> (Self, i128) {
             let mut quotient = Self::new(self);
 
-            let divisor = divisor as u128;
-            let mut last_r = 0u128;
+            let divisor = divisor as DoubleDigitT;
+            let mut last_r = 0 as DoubleDigitT;
             // Start with most significant digit
             for (i, d) in self.iter().rev().enumerate() {
-                let d = *d as u128;
+                let d = *d as DoubleDigitT;
                 // "Prefix" d with last_r (multiplies last_r by `2^digit_bits`)
                 let dividend = (last_r << DIGIT_BITS) + d;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,9 +535,9 @@ pub mod mp_int {
             // Matrix with: "digits_count" rows and "2*digits" columns
             let mut prod_rows = vec![vec![0 as DigitT; self.len() * 2]; self.len()];
 
-            // `prod_carries[i][j]` represents the carry resulting from multiplying the i-th digit
-            // of one factor by the j-th digit of the other factor. This carry must then be
-            // added to the (j+1)-th digit of the end result.
+            // `prod_carries[i][j]` represents the carry, which resulted from multiplying the i-th digit
+            // of one factor by the (j-1)-th digit of the other factor. This carry must then be added to
+            // the j-th digit of the end result.
             // First column of carries is always zero.
             let mut prod_carries = vec![vec![0 as DigitT; self.len() * 2]; self.len()];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1120,6 +1120,13 @@ pub mod mp_int {
                 let b = a.clone();
                 test_mul_correctness(a, b);
             }
+
+            #[test]
+            fn large_factors_2() {
+                let a = MPint::new(<Vec<u64>>::from(LARGE_NUM_1));
+                let b = MPint::new(<Vec<u64>>::from(LARGE_NUM_2));
+                test_mul_correctness(a.clone(), b.clone());
+            }
         }
 
         mod test_add {
@@ -1337,7 +1344,7 @@ pub mod mp_int {
         const LARGE_NUM_2: [DigitT; 64] = [
             48, 96, 67, 81, 52, 61, 27, 58, 6, 59, 73, 33, 95, 91, 77, 60, 94, 76, 86, 41, 0, 42,
             89, 93, 19, 45, 64, 47, 21, 39, 10, 13, 1, 62, 43, 68, 24, 97, 15, 36, 23, 90, 25, 74,
-            57, 82, 53, 99, 30, 4, 37, 31, 16, 7, 98, 69, 14, 92, 49, 70, 22, 80, 26, 18,
+            57, 82, 53, 99, 30, 4, 37, 31, 16, 7, 98, 69, 14, 92, 49, D_MAX, 22, 80, 26, 18,
         ];
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1260,30 +1260,18 @@ pub mod mp_int {
 
             mod large_values_4096 {
                 use super::*;
-                const LHS: [DigitT; 64] = [
-                    26, 57, 93, 1, 70, 36, 14, 42, 77, 64, 29, 44, 65, 3, 56, 84, 66, 88, 38, 94,
-                    52, 46, 73, 72, 30, 16, 8, 51, 83, 41, 34, 28, 33, 24, 40, 22, 59, 19, 99, 21,
-                    75, 13, 96, 25, 62, 0, 23, 18, 27, 32, 20, 85, 37, 86, 54, 80, 50, 9, 71, 60,
-                    55, 81, 87, 2,
-                ];
-                const RHS: [DigitT; 64] = [
-                    48, 96, 67, 81, 52, 61, 27, 58, 6, 59, 73, 33, 95, 91, 77, 60, 94, 76, 86, 41,
-                    0, 42, 89, 93, 19, 45, 64, 47, 21, 39, 10, 13, 1, 62, 43, 68, 24, 97, 15, 36,
-                    23, 90, 25, 74, 57, 82, 53, 99, 30, 4, 37, 31, 16, 7, 98, 69, 14, 92, 49, 70,
-                    22, 80, 26, 18,
-                ];
 
                 #[test]
                 fn same_signs() {
-                    let a = MPint::new(<Vec<u64>>::from(LHS));
-                    let b = MPint::new(<Vec<u64>>::from(RHS));
+                    let a = MPint::new(<Vec<u64>>::from(LARGE_NUM_1));
+                    let b = MPint::new(<Vec<u64>>::from(LARGE_NUM_2));
                     test_addition_correctness(a.clone(), b.clone());
                     test_addition_correctness(-a, -b);
                 }
                 #[test]
                 fn diff_signs() {
-                    let a = MPint::new(<Vec<u64>>::from(LHS));
-                    let b = MPint::new(<Vec<u64>>::from(RHS));
+                    let a = MPint::new(<Vec<u64>>::from(LARGE_NUM_1));
+                    let b = MPint::new(<Vec<u64>>::from(LARGE_NUM_2));
                     test_addition_correctness(a.clone(), -&b); //a + -b
                     test_addition_correctness(-&a, b.clone()); //-a + b
                     test_addition_correctness(b.clone(), -&a); // b + -a
@@ -1339,5 +1327,17 @@ pub mod mp_int {
 
             py_result.unwrap()
         }
+
+        const LARGE_NUM_1: [DigitT; 64] = [
+            26, 57, 93, 1, 70, 36, 14, 42, 77, 64, 29, 44, 65, 3, 56, 84, 66, 88, 38, 94, 52, 46,
+            73, 72, 30, 16, 8, 51, 83, 41, 34, 28, 33, 24, 40, 22, 59, 19, 99, 21, 75, 13, 96, 25,
+            62, 0, 23, 18, 27, 32, 20, 85, 37, 86, 54, 80, 50, 9, 71, 60, 55, 81, 87, 2,
+        ];
+
+        const LARGE_NUM_2: [DigitT; 64] = [
+            48, 96, 67, 81, 52, 61, 27, 58, 6, 59, 73, 33, 95, 91, 77, 60, 94, 76, 86, 41, 0, 42,
+            89, 93, 19, 45, 64, 47, 21, 39, 10, 13, 1, 62, 43, 68, 24, 97, 15, 36, 23, 90, 25, 74,
+            57, 82, 53, 99, 30, 4, 37, 31, 16, 7, 98, 69, 14, 92, 49, 70, 22, 80, 26, 18,
+        ];
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,87 +586,6 @@ pub mod mp_int {
             self.data.rotate_left(n);
         }
 
-        /// Multiplies two `MPint`, extending the width as necessary.
-        /// This uses a kind of "Operand-Scanning" algorithm.
-        #[allow(dead_code)]
-        fn extending_operand_scan_mul(&self, rhs: &Self) -> Self {
-            // ~~~~ Preamble ~~~~
-            self.assert_same_width(rhs);
-
-            // Zero short circuit
-            if self.is_zero() {
-                return self.clone();
-            } else if rhs.is_zero() {
-                return rhs.clone();
-            }
-
-            let result_sign = if self.sign == rhs.sign {
-                // same signs implicate positive result
-                Sign::Pos
-            } else {
-                // different signs implicate negative result
-                Sign::Neg
-            };
-            let max_new_width = self.width * 2;
-
-            // ~~~~ Main ~~~~
-
-            // Given `a*b = a0..an * b0..bn` where `a0..an` and `b0..bn` are the digits of the factors.
-            // Each row of following matrices represents the multiplication of a digit of one factor
-            // with each digit of the other factor, with offset of the first factors digit-position.
-
-            // Matrix with: "digits_count" rows and "2*digits" columns
-            let mut prod_rows = vec![vec![0 as DigitT; self.len() * 2]; self.len()];
-
-            // `prod_carries[i][j]` represents the carry, which resulted from multiplying the i-th digit
-            // of one factor by the (j-1)-th digit of the other factor. This carry must then be added to
-            // the j-th digit of the end result.
-            // First column of carries is always zero.
-            let mut prod_carries = vec![vec![0 as DigitT; self.len() * 2]; self.len()];
-
-            for i in 0..prod_rows.len() {
-                let b_i = rhs[i] as DoubleDigitT;
-
-                for j in 0..self.len() {
-                    let a_j = self[j] as DoubleDigitT;
-                    let prod_ij = a_j * b_i;
-
-                    prod_rows[i][j + i] = prod_ij as DigitT;
-                    prod_carries[i][j + i + 1] = (prod_ij >> DIGIT_BITS) as DigitT;
-                }
-            }
-
-            // Sum columns
-
-            let mut end_product = MPint::new(max_new_width);
-            let mut col_carry = 0 as DigitT;
-            for j in 0..prod_rows[0].len() {
-                // Add last columns carry
-                end_product += col_carry;
-
-                for i in 0..prod_rows.len() {
-                    col_carry = end_product.carry_ripple_add_bins_inplace(&MPint::from_digit(
-                        prod_rows[i][j],
-                        max_new_width,
-                    )) as u64;
-
-                    col_carry += end_product.carry_ripple_add_bins_inplace(&MPint::from_digit(
-                        prod_carries[i][j],
-                        max_new_width,
-                    )) as u64;
-                }
-
-                // Make sure next column is added to the correct position of the number system
-                end_product.rotate_digits_right(1);
-            }
-
-            // ~~~~ Epilog ~~~~
-            end_product.trim_empty_end(self.len());
-            end_product.sign = result_sign;
-
-            end_product
-        }
-
         fn trim_empty_end(&mut self, min_len: usize) {
             // Get first non-zero digit index from the end
             let mut first_non_zero = 0;
@@ -681,7 +600,6 @@ pub mod mp_int {
         }
 
         pub fn extending_mul(&self, rhs: &Self) -> Self {
-            // self.extending_operand_scan_mul(rhs)
             self.extending_prod_scan_mul(rhs)
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,13 +7,29 @@ pub enum Op {
     PLUS,
     MINUS,
     MULT,
+    DIV,
 }
-impl Op {
-    pub fn to_str(&self) -> &'static str {
-        match self {
+
+impl From<Op> for &'static str {
+    fn from(value: Op) -> Self {
+        match value {
             Op::PLUS => "+",
             Op::MINUS => "-",
             Op::MULT => "*",
+            Op::DIV => "/",
+        }
+    }
+}
+
+impl TryFrom<&'static str> for Op {
+    type Error = ParseError;
+    fn try_from(value: &'static str) -> Result<Self, Self::Error> {
+        match value {
+            "+" => Ok(Op::PLUS),
+            "-" => Ok(Op::MINUS),
+            "*" => Ok(Op::MULT),
+            "/" => Ok(Op::DIV),
+            _ => Err("unknown operator".into()),
         }
     }
 }


### PR DESCRIPTION
- Implements the `*` operator for `MPint`, utilizing a product-scanning algorithm.
- Replaces `width` field by `width()` method. That is to avoid bugs, when `data` changes and `width` is not synced accordingly.
- Somehow the subtract wrapper methods slipped in here aswell...