### PR TITLE
Handle widths dynamically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mpa_project"
 version = "0.1.0"
 edition = "2021"
+default-run = "cli"
 
 [dependencies]
 rand_pcg = "0.3.1"
@@ -18,3 +19,8 @@ features = []
 doctest = true
 name = "mpa_lib"
 path = "src/lib.rs"
+
+
+[[bin]]
+name = "cli"
+path = "src/bin/mpa_demo_cli.rs"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
 fn_single_line = true
 use_small_heuristics = "Off"
 struct_lit_width = 18              # default: 18; related to use_small_heuristics
-single_line_if_else_max_width = 50 # default: 50; related to use_small_heuristics
+single_line_if_else_max_width = 90 # default: 50; related to use_small_heuristics

--- a/src/bin/mpa_demo_cli.rs
+++ b/src/bin/mpa_demo_cli.rs
@@ -137,7 +137,7 @@ fn get_operand_from_user(args: &Cli, msg: &str) -> UserInputResult {
 
     match {
         match in_base {
-            16 => MPint::from_hex_str(&input, args.width),
+            16 => MPint::from_hex_str(&input),
             10 => MPint::from_dec_str(&input),
             _ => panic!("illegal base"),
         }

--- a/src/bin/mpa_demo_cli.rs
+++ b/src/bin/mpa_demo_cli.rs
@@ -138,7 +138,7 @@ fn get_operand_from_user(args: &Cli, msg: &str) -> UserInputResult {
     match {
         match in_base {
             16 => MPint::from_hex_str(&input, args.width),
-            10 => MPint::from_dec_str(&input, args.width),
+            10 => MPint::from_dec_str(&input),
             _ => panic!("illegal base"),
         }
     } {

--- a/src/bin/mpa_demo_cli.rs
+++ b/src/bin/mpa_demo_cli.rs
@@ -169,7 +169,7 @@ fn run_randomized_mode(args: &Cli) {
     let mut header = String::new();
     _ = writeln!(header, "+----------- Test: lhs {} rhs -----------+", args.operation);
     _ = writeln!(header, "| - Mode: Random operands");
-    _ = writeln!(header, "| - Operands width: {} bits", MPint::new(args.width).width());
+    _ = writeln!(header, "| - Operands width: {} bits", MPint::new_with_width(args.width).width());
     _ = writeln!(header, "| - Test count: {}", args.test_count);
     _ = writeln!(header, "+---------------------------------------+");
     print!("{}", header);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod mp_int {
     /// `const DIGIT_BITS`.
     /// __DO NOT CHANGE WITHOUT CAUTION__
     pub type DigitT = u64;
-    /// Type double the width of `DigitT`, sometimes needed for intermediary results
+    /// Type double the width of `DigitT`, sometimes required for intermediary results
     type DoubleDigitT = u128;
 
     /// Number of bits used per digit in the internal number system.
@@ -107,25 +107,6 @@ pub mod mp_int {
         sign: Sign,
     }
 
-    impl PartialEq for MPint {
-        fn eq(&self, other: &Self) -> bool {
-            if self.len() != other.len() {
-                false
-            } else if self.sign != other.sign {
-                // different signs only eq when both are 0
-                self.is_zero() && other.is_zero()
-            } else {
-                self.data == other.data
-            }
-        }
-    }
-
-    impl PartialEq<DigitT> for MPint {
-        fn eq(&self, other: &DigitT) -> bool {
-            self == &MPint::from_digit(*other, self.width())
-        }
-    }
-
     pub trait CreateNewFrom<T> {
         /// Provides different constructor overloads
         fn new(src: T) -> Self;
@@ -206,7 +187,6 @@ pub mod mp_int {
             width.div_ceil(DIGIT_BITS as usize)
         }
 
-        /// Calculates quotient and remainder using the given _native_ integer
         /// Calculates quotient and remainder using the given _native_ integer divisor.
         ///
         /// # Footnote
@@ -791,6 +771,27 @@ pub mod mp_int {
             // // the number as a whole overflowed.
             // // Actually we could do this check in advance by checking where the last `1`
             // // is in the last bin and compare to `rhs` accordingly.
+        }
+    }
+
+    impl PartialEq<DigitT> for MPint {
+        fn eq(&self, other: &DigitT) -> bool {
+            self == &MPint::from_digit(*other, self.width())
+        }
+    }
+
+    // TODO if different WIDTHS are finally allowed:
+    // TODO     must be changed to manually compare each element of data
+    impl PartialEq for MPint {
+        fn eq(&self, other: &Self) -> bool {
+            if self.len() != other.len() {
+                false
+            } else if self.sign != other.sign {
+                // different signs only eq when both are 0
+                self.is_zero() && other.is_zero()
+            } else {
+                self.data == other.data
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,10 +483,16 @@ pub mod mp_int {
 
         /// Helper function.
         /// Adds two number's bins and returns whether the most significant bin produced a carry.
-        /// Note that **`self` keeps its sign**, regardless of `other`'s sign.
+        /// # Note
+        /// - Both numbers shall have the __same width__.
+        /// - `self` __keeps its sign__, regardless of `other`'s sign.
+        ///
+        /// # Returns
+        /// - A `bool` representing the "Carry-Out" of the adder.
         fn carry_ripple_add_bins_inplace(&mut self, other: &MPint) -> bool {
-            let mut carry = false;
+            self.assert_same_width(other);
 
+            let mut carry = false;
             for i in 0..other.len() {
                 let digit: DigitT;
                 (digit, carry) = add_with_carry(self[i], other[i], carry);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,10 @@ pub mod mp_int {
     pub use crate::mpint;
 
     use crate::utils::{add_with_carry, div_with_rem, parse_to_digits, ParseError};
-    use std::{
-        cmp::Ordering,
-        fmt::Display,
-        mem::size_of,
-        ops::{
-            Add, AddAssign, Div, Index, IndexMut, Mul, Neg, Not, Rem, ShlAssign, Sub, SubAssign,
-        },
-        slice::Iter,
-        str::from_utf8,
+    use std::ops::{
+        Add, AddAssign, Div, Index, IndexMut, Mul, Neg, Not, Rem, ShlAssign, Sub, SubAssign,
     };
+    use std::{cmp::Ordering, fmt::Display, mem::size_of, slice::Iter, str::from_utf8};
 
     /// Type of elements representing individual digits. Directly related to the
     /// `const DIGIT_BITS`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,22 +394,15 @@ pub mod mp_int {
         /// - `Ordering` enum value, representing the relation of `self` to `other`.
         fn cmp_abs(&self, other: &MPint) -> Ordering {
             // Sort by "width"
-            let (wide, short) = if self.len() >= other.len() {
-                (self, other)
-            } else {
-                (other, self)
-            };
+            let (wide, short) =
+                if self.len() >= other.len() { (self, other) } else { (other, self) };
             let wide_is_self = std::ptr::eq(self, wide);
 
             // Check extra part in wider num
             for i in short.len()..wide.len() {
                 if wide[i] != 0 {
                     // → wide > short
-                    return if wide_is_self {
-                        Ordering::Greater
-                    } else {
-                        Ordering::Less
-                    };
+                    return if wide_is_self { Ordering::Greater } else { Ordering::Less };
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,10 +347,6 @@ pub mod mp_int {
             self.sign == Sign::Neg
         }
 
-        fn assert_same_width(&self, rhs: &MPint) {
-            assert_eq!(self.width(), rhs.width(), "operands must have equal widths");
-        }
-
         /// Returns the hexadecimal representation of this `MPint`.
         pub fn to_hex_string(&self) -> String {
             let mut hex: String = String::new();
@@ -469,7 +465,7 @@ pub mod mp_int {
         /// # Panics
         /// - When given numbers have unequal widths.
         fn carry_ripple_add_bins_inplace(&mut self, other: &MPint) -> bool {
-            self.assert_same_width(other);
+            assert_eq!(self.width(), other.width(), "operands must have equal widths");
 
             let mut carry = false;
             for i in 0..other.len() {
@@ -703,7 +699,7 @@ pub mod mp_int {
         /// calculate each result digit one at a time.
         fn extending_prod_scan_mul(&self, rhs: &Self) -> Self {
             // ~~~~ Preamble ~~~~
-            self.assert_same_width(rhs);
+            assert_eq!(self.width(), rhs.width(), "operands must have equal widths");
 
             // Zero short circuit
             if self.is_zero() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ pub mod mp_int {
         /// In place adds `self` to `rhs`.\
         /// Returns a boolean indicating whether an arithmetic overflow occured.
         fn overflowing_add(&mut self, mut rhs: Self) -> bool {
-            self.assert_same_width(&rhs);
+            self.normalize_widths(&mut rhs);
             let rhs = &mut rhs;
 
             let mut carry: bool = false;
@@ -669,7 +669,10 @@ pub mod mp_int {
     impl AddAssign for MPint {
         /// Performs the += operation. Arithmetic overflows are silently ignored.
         fn add_assign(&mut self, rhs: Self) {
-            self.overflowing_add(rhs);
+            let overflow = self.overflowing_add(rhs);
+            if overflow {
+                self.data.push(1);
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod mp_int {
         }
     }
 
+    /// The core datatype for multiple precision integers.
     #[derive(Debug, Clone)]
     pub struct MPint {
         data: Vec<DigitT>,
@@ -162,11 +163,11 @@ pub mod mp_int {
         }
 
         /// Tries to in-place extend or truncate `self` to the specified bit-width.
-        /// Useful e.g. to adjust an instance to a multiplication result.
+        /// Useful e.g. to adjust another instance to a multiplication result.
         ///
         /// On success, the actual new width will be a multiple of `DIGITS_WIDTH`.
         /// `Err(self)` containing the untouched instance is returned, if non-zero
-        /// bins had to be dropped to meet the desired `target_width`.
+        /// bins would have to be dropped to meet the desired `target_width`.
         pub fn try_set_width(mut self, target_width: usize) -> Result<Self, Self> {
             let new_bins_count = Self::width_to_bins_count(target_width);
             let old_bins_count = self.data.len();
@@ -245,7 +246,8 @@ pub mod mp_int {
             (quotient, last_r)
         }
 
-        /// Gets max number of digits (in regards to the internal radix).
+        /// Gets number of digits in regards to the internal radix.
+        /// Note that this includes trailing "0".
         pub fn len(&self) -> usize {
             self.data.len()
         }
@@ -362,7 +364,8 @@ pub mod mp_int {
             result
         }
 
-        /// Alias for `into_iter()`
+        /// Alias for `into_iter()`. Returns an iterator over the underlying digits
+        /// in _little-endian_ order.
         pub fn iter(&self) -> Iter<DigitT> {
             self.into_iter()
         }
@@ -375,6 +378,7 @@ pub mod mp_int {
             assert_eq!(self.width(), rhs.width(), "operands must have equal widths");
         }
 
+        /// Returns the hexadecimal representation of this `MPint`.
         pub fn to_hex_string(&self) -> String {
             let mut hex: String = String::new();
             if self.is_negative() {
@@ -388,7 +392,8 @@ pub mod mp_int {
             hex
         }
 
-        /// Derives a decimal string representation of `self`, utilizing *Division-Remainder Method*.
+        /// Derives a decimal string representation of `self`, utilizing the
+        /// _Division-Remainder Method_.
         pub fn to_dec_string(&self) -> String {
             // passing this as param should suffice to enable arbitrary output bases
             const BASE: u8 = 10;
@@ -461,8 +466,11 @@ pub mod mp_int {
             self.data.iter().all(|d| *d == 0)
         }
 
-        /// Calculates the two's complement of the given number.
-        /// Note that the result will have an _inverted sign_.
+        /// Calculates the two's complement of the given number. This operation depends
+        /// on the underlying width and, by definition, the result is mathematicaly
+        /// compatible only with `MPint` of __same widths__.
+        ///
+        /// Note that the result will have an __inverted sign__.
         fn twos_complement_inplace(&mut self) {
             _ = self.not();
             let result_sign = !self.sign;
@@ -705,6 +713,7 @@ pub mod mp_int {
             self.data.rotate_left(n);
         }
 
+        /// Removes empty (i.e. `0`) bins from the end
         fn trim_empty_end(&mut self, min_len: usize) {
             // Get first non-zero digit index from the end
             let mut first_non_zero = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
-use mpa_lib::mp_int::MPint;
+use mpa_lib::mp_int::*;
 
 fn main() {
-    let two = MPint::from_digit(2, 128);
+    let two = MPint::new(2_u128);
     let div_two_by_three = &two / 3;
     let mod_two_by_three = &two % 3;
     println!("→→→→ two / 3 = {:?}", div_two_by_three); // >>> [0,0]
     println!("→→→→ two % 3 = {:?}", mod_two_by_three); // >>> 2
 
-    let ten = MPint::from_digit(10, 128);
+    let ten = MPint::new(10_u128);
     let div_ten_by_three = &ten / 3;
     let mod_ten_by_three = &ten % 3;
     println!("→→→→ ten / 3 = {:?}", div_ten_by_three); // >>> [3,0]
@@ -18,11 +18,11 @@ fn main() {
     let width = 123;
     let num = MPint::from_dec_str(num_str, width).unwrap();
     println!("{:?}", num); // >>> MPint { width: 128, data: [1234, 0], sign: Pos }
-    println!("{}", num); // >>> 0000000000000000 00000000000004D2
+    println!("{}", num); // >>> 000000000000000000000000000004D2
 
     let num_str = "-1234";
     let width = 123;
     let num = MPint::from_dec_str(num_str, width).unwrap();
     println!("{:?}", num); // >>> MPint { width: 128, data: [1234, 0], sign: Neg }
-    println!("{}", num); // >>> -0000000000000000 00000000000004D2
+    println!("{}", num); // >>> -000000000000000000000000000004D2
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,14 +15,12 @@ fn main() {
 
     // from_str
     let num_str = "1234";
-    let width = 123;
-    let num = MPint::from_dec_str(num_str, width).unwrap();
-    println!("{:?}", num); // >>> MPint { width: 128, data: [1234, 0], sign: Pos }
+    let num = MPint::from_dec_str(num_str).unwrap();
+    println!("{:?}", num); // >>> MPint { data: [1234, 0], sign: Pos }
     println!("{}", num); // >>> 000000000000000000000000000004D2
 
     let num_str = "-1234";
-    let width = 123;
-    let num = MPint::from_dec_str(num_str, width).unwrap();
-    println!("{:?}", num); // >>> MPint { width: 128, data: [1234, 0], sign: Neg }
+    let num = MPint::from_dec_str(num_str).unwrap();
+    println!("{:?}", num); // >>> MPint { data: [1234, 0], sign: Neg }
     println!("{}", num); // >>> -000000000000000000000000000004D2
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,12 @@ use std::error::Error;
 use std::fmt::Display;
 use std::ops::{Div, Rem};
 
+/// Returns the _minimal_ bit width required to represent all possible numbers
+/// build from `dec_width` decimal digits.
+pub fn approx_bit_width(dec_width: usize) -> usize {
+    (std::f64::consts::LOG2_10 * dec_width as f64).ceil() as usize
+}
+
 /// Basically a full adder for `u64`
 ///
 /// # Explanation


### PR DESCRIPTION
In general terms these changes aim to adapt all relevant parts of the codebase, such that number widths are handled dynamically.

The two main aspects regarding number width handling are:
1. Mandatory width specification on most constructors.
    - Widths do not have to be explicitly specified anymore and are handled dynamically behind the scenes now.

2. Same width requirement for operands on most operations.
    - These restrictions were mostly removed and differing widths of operands are now allowed.