### PR TITLE
cli result export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,10 @@ default-run = "cli"
 rand_pcg = "0.3.1"
 rand = "0.8.5"
 clap = { version = "4.5.8", features = ["derive"] }
+csv = "1.3.0"
 
-[dev-dependencies.pyo3]
-version = "0.21.2"
-# features = ["auto-initialize"]
-default-features = false
-features = []
+[dev-dependencies]
+pyo3 = { version = "0.21.2", default-features = false, features = [] }
 
 [lib]
 doctest = true

--- a/src/bin/mpa_demo_cli.rs
+++ b/src/bin/mpa_demo_cli.rs
@@ -56,6 +56,10 @@ use std::{
     str::FromStr,
 };
 
+/// Options exlusive to the random test mode
+const RAND_TEST_MODE_OPTS: [&'static str; 5] =
+    ["min_width", "max_width", "test_count", "seed", "out"];
+
 #[derive(Debug, Parser)]
 #[command(version, about, long_about = None, arg_required_else_help = true)]
 pub struct Cli {
@@ -78,13 +82,17 @@ pub struct Cli {
     #[arg(long, short)]
     seed: Option<u128>,
 
+    /// Export the random operations along with the results into the specified file.
+    #[arg(long)]
+    out: Option<String>,
+
     /// Interactive mode. Allows manually specify operands in a loop.
     /// Enter `q` to quit.
-    #[arg(long, short, conflicts_with_all([ "min_width", "max_width", "test_count", "seed"]))]
+    #[arg(long, short, conflicts_with_all(RAND_TEST_MODE_OPTS))]
     interactive: bool,
 
     /// Base of the input and output in interactive mode.
-    #[arg(long, short, conflicts_with_all([ "min_width", "max_width", "test_count", "seed"]), default_value="10",
+    #[arg(long, short, conflicts_with_all(RAND_TEST_MODE_OPTS), default_value="10",
         value_parser(clap::builder::PossibleValuesParser::new(["10", "16"])))]
     base: String,
 }


### PR DESCRIPTION
Added `export` option to demo CLI:
- Allows specifying an output file for the "randomized test operations mode"
- The file will contain the generated operations and their calculated results
- The generated lines are in a format such that they can be easily interpreted by the Python REPL (or another appropriate tool) for verification